### PR TITLE
Correctly deletes events in javascript queue when they have been processed fixes #274 #278

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ def create
 end
 ````
 
+Note that if you do not trigger the event, a success will be automatically triggered with no data. You can change this behavior by editing the gem configurations and add : `config.trigger_success_by_default = false`.
+
 If you're feeling truly lazy, just trigger the failure callback with an
 exception.
 

--- a/lib/assets/javascripts/websocket_rails/event.js.coffee
+++ b/lib/assets/javascripts/websocket_rails/event.js.coffee
@@ -4,9 +4,9 @@ The Event object stores all the relevant event information.
 
 class WebSocketRails.Event
 
-  @SUCCEEDED = 0
-  @FAILED = 1
-  @FINISHED_WITHOUT_FAILURE = 2
+  SUCCEEDED: 0
+  FAILED: 1
+  FINISHED_WITHOUT_FAILURE: 2
 
   constructor: (data, @success_callback, @failure_callback) ->
     @name    = data[0]

--- a/lib/assets/javascripts/websocket_rails/event.js.coffee
+++ b/lib/assets/javascripts/websocket_rails/event.js.coffee
@@ -4,6 +4,10 @@ The Event object stores all the relevant event information.
 
 class WebSocketRails.Event
 
+  @SUCCEEDED = 0
+  @FAILED = 1
+  @FINISHED_WITHOUT_FAILURE = 2
+
   constructor: (data, @success_callback, @failure_callback) ->
     @name    = data[0]
     attr     = data[1]
@@ -36,7 +40,7 @@ class WebSocketRails.Event
     token: @token
 
   run_callbacks: (@success, @result) ->
-    if @success == true
+    if @success == @SUCCEEDED
       @success_callback?(@result)
-    else
+    else if @success == @FAILED
       @failure_callback?(@result)

--- a/lib/generators/websocket_rails/install/templates/websocket_rails.rb
+++ b/lib/generators/websocket_rails/install/templates/websocket_rails.rb
@@ -60,4 +60,9 @@ WebsocketRails.setup do |config|
   # List here the origin domains allowed to perform the request.
   # config.allowed_origins = ['http://localhost:3000']
 
+  # Uncomment this option to change the default behavior when 
+  # trigger_success or trigger_failure are not called in the action
+  # of the WebsocketController. (default is true)
+  # confid.trigger_success_by_default = false
+
 end

--- a/lib/spec_helpers/matchers/trigger_matchers.rb
+++ b/lib/spec_helpers/matchers/trigger_matchers.rb
@@ -26,19 +26,27 @@ module WebsocketRails
       data ? "with data #{data}": 'with no data'
     end
 
-    def self.actual_for_spec_message(event, success)
+    def self.actual_for_spec_message(event)
       if event.triggered?
+        success = event.success
         if success.nil?
           "triggered message #{actual_data_for_spec_message(event.data)}"
         else
-          "triggered #{event.success ? 'a success' : 'a failure' } message #{actual_data_for_spec_message(event.data)}"
+          success_state = 
+          case success
+          when 0 then "a success"
+          when 1 then "a failure"
+          when 2 then "a no result"
+          else success
+          end
+          "triggered #{success_state} message #{actual_data_for_spec_message(event.data)}"
         end
       else
         'did not trigger any message'
       end
     end
 
-    def self.verify_trigger(event, data, success)
+    def self.verify_trigger(event, data, success=nil)
       return false unless event.triggered?
       return false unless compare_trigger_data(event, data)
       success.nil? || success == event.success
@@ -50,14 +58,13 @@ end
 
 
 RSpec::Matchers.define :trigger_message do |data|
-
   match do |event|
-    WebsocketRails::SpecHelpers.verify_trigger event, data, nil
+    WebsocketRails::SpecHelpers.verify_trigger event, data
   end
 
   failure_message_for_should do |event|
     "expected #{event.encoded_name} to trigger message#{WebsocketRails::SpecHelpers.expected_data_for_spec_message data}, " +
-        "instead it #{WebsocketRails::SpecHelpers.actual_for_spec_message event, nil}"
+        "instead it #{WebsocketRails::SpecHelpers.actual_for_spec_message event}"
   end
 
   failure_message_for_should_not do |event|
@@ -67,18 +74,17 @@ RSpec::Matchers.define :trigger_message do |data|
   description do
     "trigger message#{WebsocketRails::SpecHelpers.expected_data_for_spec_message data}"
   end
-
 end
 
 RSpec::Matchers.define :trigger_success_message do |data|
 
   match do |event|
-    WebsocketRails::SpecHelpers.verify_trigger event, data, true
+    WebsocketRails::SpecHelpers.verify_trigger event, data, 0
   end
 
   failure_message_for_should do |event|
     "expected #{event.encoded_name} to trigger success message#{WebsocketRails::SpecHelpers.expected_data_for_spec_message data}, "+
-        "instead it #{WebsocketRails::SpecHelpers.actual_for_spec_message event, true}"
+        "instead it #{WebsocketRails::SpecHelpers.actual_for_spec_message event}"
   end
 
   failure_message_for_should_not do |event|
@@ -94,12 +100,12 @@ end
 RSpec::Matchers.define :trigger_failure_message do |data|
 
   match do |event|
-    WebsocketRails::SpecHelpers.verify_trigger event, data, false
+    WebsocketRails::SpecHelpers.verify_trigger event, data, 1
   end
 
   failure_message_for_should do |event|
     "expected #{event.encoded_name} to trigger failure message#{WebsocketRails::SpecHelpers.expected_data_for_spec_message data}, " +
-        "instead it #{WebsocketRails::SpecHelpers.actual_for_spec_message event, true}"
+        "instead it #{WebsocketRails::SpecHelpers.actual_for_spec_message event}"
   end
 
   failure_message_for_should_not do |event|
@@ -110,4 +116,23 @@ RSpec::Matchers.define :trigger_failure_message do |data|
     "trigger failure message#{WebsocketRails::SpecHelpers.expected_data_for_spec_message data}"
   end
 
+end
+
+Rspec::Matchers.define :trigger_no_result_message do |data|
+  match do |event|
+    WebsocketRails::SpecHelpers.verify_trigger event, data, 2
+  end
+
+  failure_message_for_should do |event|
+    "expected #{event.encoded_name} to trigger no result message (success == 2)#{WebsocketRails::SpecHelpers.expected_data_for_spec_message data}, "+
+      "instead it #{WebsocketRails::SpecHelpers.actual_for_spec_message event}"
+  end
+
+  failure_message_for_should_not do |event|
+    "expected #{event.encoded_name} not to trigger no result message (success == 2)"
+  end
+
+  description do 
+    "trigger no result message #{WebsocketRails::SpecHelpers.expected_data_for_spec_message data}"
+  end
 end

--- a/lib/websocket_rails/base_controller.rb
+++ b/lib/websocket_rails/base_controller.rb
@@ -37,6 +37,9 @@ module WebsocketRails
     include Metal
     include AbstractController::Callbacks
 
+    # Add a callback to notify the javascript client that the event has been treated
+    after_action :trigger_finished
+
     # Tell Rails that BaseController and children can be reloaded when in
     # the Development environment.
     def self.inherited(controller)
@@ -98,7 +101,7 @@ module WebsocketRails
     # this action. The object passed to this method will be passed as an argument to
     # the callback function on the client.
     def trigger_success(data=nil)
-      event.success = true
+      event.success = Event::SUCCEEDED
       event.data = data
       event.trigger
     end
@@ -107,7 +110,7 @@ module WebsocketRails
     # this action. The object passed to this method will be passed as an argument to
     # the callback function on the client.
     def trigger_failure(data=nil)
-      event.success = false
+      event.success = Event::FAILED
       event.data = data
       event.trigger
     end
@@ -191,6 +194,16 @@ module WebsocketRails
       else
         super
       end
+    end
+
+    def trigger_finished
+      return if event.success
+      if config.trigger_success_by_default
+        event.success = Event::SUCCEEDED
+      else
+        event.success = Event::FINISHED_WITHOUT_RESULT
+      end
+      event.trigger
     end
 
   end

--- a/lib/websocket_rails/base_controller.rb
+++ b/lib/websocket_rails/base_controller.rb
@@ -197,7 +197,7 @@ module WebsocketRails
     end
 
     def trigger_finished
-      return if event.success
+      return if event.nil? || event.success
       if config.trigger_success_by_default
         event.success = Event::SUCCEEDED
       else

--- a/lib/websocket_rails/base_controller.rb
+++ b/lib/websocket_rails/base_controller.rb
@@ -198,7 +198,7 @@ module WebsocketRails
 
     def trigger_finished
       return if event.nil? || event.success
-      if config.trigger_success_by_default
+      if WebsocketRails.config.trigger_success_by_default
         event.success = Event::SUCCEEDED
       else
         event.success = Event::FINISHED_WITHOUT_RESULT

--- a/lib/websocket_rails/base_controller.rb
+++ b/lib/websocket_rails/base_controller.rb
@@ -25,6 +25,7 @@ module WebsocketRails
       def process_action(method, event)
         if respond_to?(method)
           self.send(method)
+          trigger_finished
         else
           raise EventRoutingError.new(event, self, method)
         end
@@ -36,9 +37,6 @@ module WebsocketRails
 
     include Metal
     include AbstractController::Callbacks
-
-    # Add a callback to notify the javascript client that the event has been treated
-    after_action :trigger_finished
 
     # Tell Rails that BaseController and children can be reloaded when in
     # the Development environment.

--- a/lib/websocket_rails/configuration.rb
+++ b/lib/websocket_rails/configuration.rb
@@ -165,5 +165,13 @@ module WebsocketRails
       @default_ping_interval = interval.to_i
     end
 
+    def trigger_success_by_default
+      @trigger_success_by_default ||= true
+    end
+
+    def trigger_success_by_default= value
+      @trigger_success_by_default = value
+    end
+
   end
 end

--- a/lib/websocket_rails/event.rb
+++ b/lib/websocket_rails/event.rb
@@ -63,6 +63,10 @@ module WebsocketRails
 
     extend Logging
 
+    SUCCEEDED = 0
+    FAILED = 1
+    FINISHED_WITHOUT_RESULT = 2
+
     def self.log_header
       "Event"
     end

--- a/spec/javascripts/websocket_rails/event_spec.coffee
+++ b/spec/javascripts/websocket_rails/event_spec.coffee
@@ -47,10 +47,8 @@ describe 'WebSocketRails.Event', ->
 
   describe '.run_callbacks()', ->
     beforeEach ->
-      success_func = (data) ->
-        "success:" + data
-      failure_func = (data) ->
-        "failure:" + data
+      success_func = ->
+      failure_func = ->
       @data = ['event', {data: { message: 'test'} }, 12345]
       @event = new WebSocketRails.Event(@data, success_func, failure_func)
       spyOn @event, 'success_callback'

--- a/spec/javascripts/websocket_rails/event_spec.coffee
+++ b/spec/javascripts/websocket_rails/event_spec.coffee
@@ -48,22 +48,36 @@ describe 'WebSocketRails.Event', ->
   describe '.run_callbacks()', ->
     beforeEach ->
       success_func = (data) ->
-        data
+        "success:" + data
       failure_func = (data) ->
-        data
+        "failure:" + data
       @data = ['event', {data: { message: 'test'} }, 12345]
       @event = new WebSocketRails.Event(@data, success_func, failure_func)
+      spyOn @event, 'success_callback'
+      spyOn @event, 'failure_callback'
 
     describe 'when successful', ->
-      it 'should run the success callback when passed true', ->
-        expect(@event.run_callbacks(true, 'success')).toEqual 'success'
+      beforeEach ->
+        @event.run_callbacks 0, 'foo'
 
-      it 'should not run the failure callback', ->
-        expect(@event.run_callbacks(true, 'success')).toBeUndefined
+      it 'should run the success callback when passed 0', ->
+        expect(@event.success_callback).toHaveBeenCalledWith('foo')
+
+      it 'should not run the failure callback when passed 0', ->
+        expect(@event.failure_callback).not.toHaveBeenCalled()
 
     describe 'when failure', ->
-      it 'should run the failure callback when passed true', ->
-        expect(@event.run_callbacks(false, 'failure')).toEqual 'failure'
+      beforeEach ->
+        @event.run_callbacks 1, 'foo'
 
-      it 'should not run the failure callback', ->
-        expect(@event.run_callbacks(false, 'failure')).toBeUndefined
+      it 'should run the failure callback when passed 1', ->
+        expect(@event.failure_callback).toHaveBeenCalledWith('foo')
+
+      it 'should not run the success callback when passed 1', ->
+        expect(@event.success_callback).not.toHaveBeenCalled()
+
+    describe 'when finished without result', ->
+      it 'should not run any callbacks when passed 2', ->
+        @event.run_callbacks 2, 'foo'
+        expect(@event.success_callback).not.toHaveBeenCalled()
+        expect(@event.failure_callback).not.toHaveBeenCalled()

--- a/spec/javascripts/websocket_rails/websocket_rails_spec.coffee
+++ b/spec/javascripts/websocket_rails/websocket_rails_spec.coffee
@@ -164,17 +164,16 @@ describe 'WebSocketRails:', ->
 
       describe 'result events', ->
         beforeEach ->
-          @attributes['success'] = true
+          @attributes['success'] = 2
           @attributes['id'] = 1
-          @event = { run_callbacks: (data) -> }
-          @event_mock = sinon.mock @event
-          @dispatcher.queue[1] = @event
           @event_data = [['event',@attributes]]
+          @event = new WebSocketRails.Event @event_data
+          @dispatcher.queue[1] = @event
 
         it 'should run callbacks for result events', ->
-          @event_mock.expects('run_callbacks').once()
+          spyOn(@event, 'run_callbacks')
           @dispatcher.new_message @event_data
-          @event_mock.verify()
+          expect(@event.run_callbacks).toHaveBeenCalledWith(2, 'message')
 
         it 'should remove the event from the queue', ->
           @dispatcher.new_message @event_data


### PR DESCRIPTION
The javascript queue is now correctly updated and a new configuration config.trigger_success_by_default (Boolean, defaults to true) exists. A result is triggered for each event, and the default result is success.
